### PR TITLE
Correct typo: LEVEL -> LEVELS

### DIFF
--- a/lib/rev-api/models/order_request.rb
+++ b/lib/rev-api/models/order_request.rb
@@ -211,7 +211,7 @@ module Rev
     #        - :final_only - (the default), notification is sent only when the order is complete
     def initialize(url, level = nil)
       @url = url
-      @level = level ? level : LEVEL[:final_only]
+      @level = level ? level : LEVELS[:final_only]
     end
   end
 end


### PR DESCRIPTION
Fix a typo that would result in an exception of "uninitialized constant Rev::Notification::LEVEL", as the ternary statement in `Rev::Notification` was mistakenly looking for `LEVEL[:final_only]`