### PR TITLE
Punt Payment deprecation noise

### DIFF
--- a/lib/rev-api/models/order_request.rb
+++ b/lib/rev-api/models/order_request.rb
@@ -68,7 +68,6 @@ module Rev
 
     # @param type [String] payment method
     def initialize(type)
-      warn "[DEPRECATION] `Payment` option is now optional, since it will always default to AccountBalance"
       @type = type
     end
 


### PR DESCRIPTION
Noise in the console when outputting AIV order placement results, hard to read.

the property by itself already has `@deprecated` comment, so for developers it should be obvious. Plus, we deprecated it a while ago